### PR TITLE
feat(modules/nixos/server): 所有服务器都应该默认启用 node exporter

### DIFF
--- a/modules/nixos/server/prometheus.nix
+++ b/modules/nixos/server/prometheus.nix
@@ -1,0 +1,16 @@
+{
+  # https://nixos.org/manual/nixos/stable/#module-services-prometheus-exporters
+  services.prometheus.exporters.node = {
+    enable = true;
+    port = 9100;
+    enabledCollectors = [
+      "logind"
+      "systemd"
+    ];
+    disabledCollectors = [
+      "textfile"
+    ];
+    openFirewall = true;
+    firewallFilter = "-i br0 -p tcp -m tcp --dport 9100";
+  };
+}


### PR DESCRIPTION
方便监控所有服务器的状态。